### PR TITLE
docs: renaming issue tmplt according to docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -9,6 +9,7 @@ body:
     attributes:
       label: "What happened?"
       description: "Please provide a clear description of what happened."
+    validations:
       required: true
 
   - type: textarea
@@ -16,6 +17,7 @@ body:
     attributes:
       label: "Expected behavior"
       description: "Please provide a clear description of what you expected to happen."
+    validations:
       required: true
 
   - type: textarea
@@ -28,6 +30,7 @@ body:
         - Helm Version:
         - Namespace Affected:
         - Any other relevant environment details:
+    validations:
       required: true
 
   - type: textarea
@@ -35,6 +38,7 @@ body:
     attributes:
       label: "Reproduction steps"
       description: "Please provide steps to reproduce the bug as minimally and precisely as possible."
+    validations:
       required: true
 
   - type: textarea
@@ -42,6 +46,7 @@ body:
     attributes:
       label: "Possible Solution"
       description: "If you have any suggestions on how to fix the bug, please provide them."
+    validations:
       required: false
 
   - type: textarea
@@ -49,4 +54,5 @@ body:
     attributes:
       label: "Additional Information"
       description: "Any additional information or context that may be helpful in understanding or resolving the issue."
+    validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.yml
@@ -9,6 +9,7 @@ body:
     attributes:
       label: "Description"
       description: "A clear and concise description of the new feature you are requesting."
+    validations:
       required: true
 
   - type: textarea
@@ -16,6 +17,7 @@ body:
     attributes:
       label: "Problem or Motivation"
       description: "Explain the problem or motivation behind the feature request. What issue or need does it address?"
+    validations:
       required: true
 
   - type: textarea
@@ -30,6 +32,7 @@ body:
     attributes:
       label: "Additional Information"
       description: "Any additional information or context that may be helpful in understanding your feature request."
+    validations:
       required: false
 
   - type: textarea
@@ -37,6 +40,7 @@ body:
     attributes:
       label: "Related Issues"
       description: "If there are any related issues or pull requests, please mention them here."
+    validations:
       required: false
 
   - type: textarea
@@ -44,6 +48,7 @@ body:
     attributes:
       label: "Contribution"
       description: "If you are interested in contributing to the development of this feature, please let us know."
+    validations:
       required: false
 
   - type: textarea
@@ -51,6 +56,7 @@ body:
     attributes:
       label: "Implementation Suggestions"
       description: "If you have any suggestions on how to implement this feature or specific technical considerations, please provide them."
+    validations:
       required: false
 
   - type: textarea
@@ -58,4 +64,5 @@ body:
     attributes:
       label: "Other Comments"
       description: "Any other comments, ideas, or thoughts you'd like to add."
+    validations:
       required: false


### PR DESCRIPTION
### Description
Renaming templates as per yml requirements in github docs

