### PR TITLE
chore: doubled scrapeInterval for Prometheus

### DIFF
--- a/monitoring/values/kube-prometheus-stack.yaml
+++ b/monitoring/values/kube-prometheus-stack.yaml
@@ -11,6 +11,7 @@ prometheus:
     serviceMonitorSelectorNilUsesHelmValues: false
     podMonitorSelectorNilUsesHelmValues: false
     probeSelectorNilUsesHelmValues: false
+    scrapeInterval: 60s
     storageSpec:
       volumeClaimTemplate:
         spec:


### PR DESCRIPTION
### Description
[Kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/blob/d8b6895a9ecc8c11cf2e81e2b9302358143d6b08/charts/kube-prometheus-stack/values.yaml#L2840-L2844) `scrapeInterval` was set to defaul 30s which is 2 DPM (Data Points per Minute) which is not the global default of Prometheus config. This should be set to default 60s so that users don't have issues with increased billing should they be using Grafana Cloud