### PR TITLE
fix(postgres): disable install validation

### DIFF
--- a/postgres-operator/helmfile.yaml
+++ b/postgres-operator/helmfile.yaml
@@ -91,6 +91,7 @@ templates:
     version: 1.8.2
     inherit:
       - template: defaults
+    disableValidationOnInstall: true
   
 releases:
   {{- $release := "postgres-operator" }}

--- a/src/schemas/postgres-operator.cue
+++ b/src/schemas/postgres-operator.cue
@@ -35,7 +35,11 @@ package LaunchpadNamespaces
 		releases: {
 			"postgres-operator": {
 				chart: {_repositories["postgres-operator-charts"].charts["postgres-operator"]}
-				_template: {version: "1.8.2"}
+				_template: {
+					version: "1.8.2"
+					// so that it can be installed in the absence of the CRDs
+					disableValidationOnInstall: true
+				}
 			}
 		}
 


### PR DESCRIPTION
While the cluster does not have the CRDs installed yet, validation is not possible.