### PR TITLE
feat: add ability to specify kubeVersion

### DIFF
--- a/arbitrum/README.md
+++ b/arbitrum/README.md
@@ -116,6 +116,7 @@ arbitrum&#8209;nitro | object |  |  |
 arbitrum&#8209;nitro.mergeValues | boolean | true |  |
 arbitrum&#8209;nitro.values | (object *or* list of objects) |  |  |
 flavor | string |  |  |
+kubeVersion | string |  | Specifies the kubernetes API version, useful in helm templating environment |
 labels | object |  | Adds labels to releases on this namespace |
 proxyd | object |  |  |
 proxyd.mergeValues | boolean | true |  |

--- a/arbitrum/helmfile.yaml
+++ b/arbitrum/helmfile.yaml
@@ -58,6 +58,10 @@ transformers:
 helmDefaults:
 {{ $__helmDefaults | toYaml | indent 2 }}
 
+{{ if ( hasKey .Values "kubeVersion" ) }}
+kubeVersion: {{ .Values.kubeVersion }}
+{{ end }}
+
 #set default flavor when missing
 {{ if not ( hasKey .Values "flavor" ) }}
 {{ $_ := set .Values "flavor" "mainnet" }}

--- a/avalanche/README.md
+++ b/avalanche/README.md
@@ -111,6 +111,7 @@ avalanche | object |  |  |
 avalanche.mergeValues | boolean | true |  |
 avalanche.values | (object *or* list of objects) |  |  |
 flavor | string |  | suitable defaults for a mainnet archive node |
+kubeVersion | string |  | Specifies the kubernetes API version, useful in helm templating environment |
 labels | object |  | Adds labels to releases on this namespace |
 proxyd | object |  |  |
 proxyd.mergeValues | boolean | true |  |

--- a/avalanche/helmfile.yaml
+++ b/avalanche/helmfile.yaml
@@ -58,6 +58,10 @@ transformers:
 helmDefaults:
 {{ $__helmDefaults | toYaml | indent 2 }}
 
+{{ if ( hasKey .Values "kubeVersion" ) }}
+kubeVersion: {{ .Values.kubeVersion }}
+{{ end }}
+
 #set default flavor when missing
 {{ if not ( hasKey .Values "flavor" ) }}
 {{ $_ := set .Values "flavor" "mainnet" }}

--- a/celo/README.md
+++ b/celo/README.md
@@ -111,6 +111,7 @@ celo | object |  |  |
 celo.mergeValues | boolean | true |  |
 celo.values | (object *or* list of objects) |  |  |
 flavor | string |  | suitable defaults for a mainnet archive node |
+kubeVersion | string |  | Specifies the kubernetes API version, useful in helm templating environment |
 labels | object |  | Adds labels to releases on this namespace |
 proxyd | object |  |  |
 proxyd.mergeValues | boolean | true |  |

--- a/celo/helmfile.yaml
+++ b/celo/helmfile.yaml
@@ -58,6 +58,10 @@ transformers:
 helmDefaults:
 {{ $__helmDefaults | toYaml | indent 2 }}
 
+{{ if ( hasKey .Values "kubeVersion" ) }}
+kubeVersion: {{ .Values.kubeVersion }}
+{{ end }}
+
 #set default flavor when missing
 {{ if not ( hasKey .Values "flavor" ) }}
 {{ $_ := set .Values "flavor" "mainnet" }}

--- a/ethereum/README.md
+++ b/ethereum/README.md
@@ -113,6 +113,7 @@ erigon | object |  |  |
 erigon.mergeValues | boolean | true |  |
 erigon.values | (object *or* list of objects) |  |  |
 flavor | string |  |  |
+kubeVersion | string |  | Specifies the kubernetes API version, useful in helm templating environment |
 labels | object |  | Adds labels to releases on this namespace |
 nimbus | object |  |  |
 nimbus.mergeValues | boolean | true |  |

--- a/ethereum/helmfile.yaml
+++ b/ethereum/helmfile.yaml
@@ -58,6 +58,10 @@ transformers:
 helmDefaults:
 {{ $__helmDefaults | toYaml | indent 2 }}
 
+{{ if ( hasKey .Values "kubeVersion" ) }}
+kubeVersion: {{ .Values.kubeVersion }}
+{{ end }}
+
 #set default flavor when missing
 {{ if not ( hasKey .Values "flavor" ) }}
 {{ $_ := set .Values "flavor" "mainnet" }}

--- a/gnosis/README.md
+++ b/gnosis/README.md
@@ -110,6 +110,7 @@ helmfiles:
 | :--- | :---: | :--- | :--- |
 annotations | object |  | Add annotations to releases on this namespace |
 flavor | string |  | suitable defaults for a mainnet archive node |
+kubeVersion | string |  | Specifies the kubernetes API version, useful in helm templating environment |
 labels | object |  | Adds labels to releases on this namespace |
 nethermind | object |  |  |
 nethermind.mergeValues | boolean | true |  |

--- a/gnosis/helmfile.yaml
+++ b/gnosis/helmfile.yaml
@@ -58,6 +58,10 @@ transformers:
 helmDefaults:
 {{ $__helmDefaults | toYaml | indent 2 }}
 
+{{ if ( hasKey .Values "kubeVersion" ) }}
+kubeVersion: {{ .Values.kubeVersion }}
+{{ end }}
+
 #set default flavor when missing
 {{ if not ( hasKey .Values "flavor" ) }}
 {{ $_ := set .Values "flavor" "mainnet" }}

--- a/graph/README.md
+++ b/graph/README.md
@@ -120,6 +120,7 @@ graph&#8209;node.values | (object *or* list of objects) |  |  |
 graph&#8209;toolbox | object |  |  |
 graph&#8209;toolbox.mergeValues | boolean | true |  |
 graph&#8209;toolbox.values | (object *or* list of objects) |  |  |
+kubeVersion | string |  | Specifies the kubernetes API version, useful in helm templating environment |
 labels | object |  | Adds labels to releases on this namespace |
 targetNamespace | string | graph-goerli | the default is graph-<flavor> |
 helmDefaults | object |  |  |

--- a/graph/helmfile.yaml
+++ b/graph/helmfile.yaml
@@ -58,6 +58,10 @@ transformers:
 helmDefaults:
 {{ $__helmDefaults | toYaml | indent 2 }}
 
+{{ if ( hasKey .Values "kubeVersion" ) }}
+kubeVersion: {{ .Values.kubeVersion }}
+{{ end }}
+
 #set default flavor when missing
 {{ if not ( hasKey .Values "flavor" ) }}
 {{ $_ := set .Values "flavor" "goerli" }}

--- a/ingress/README.md
+++ b/ingress/README.md
@@ -119,6 +119,7 @@ features | list of strings | [ingress, cert-manager] | *enum of:&nbsp;&nbsp;(ing
 ingress&#8209;nginx | object |  |  |
 ingress&#8209;nginx.mergeValues | boolean | true |  |
 ingress&#8209;nginx.values | (object *or* list of objects) |  |  |
+kubeVersion | string |  | Specifies the kubernetes API version, useful in helm templating environment |
 labels | object |  | Adds labels to releases on this namespace |
 targetNamespace | string | ingress | Sets the cluster namespace in which the releases will be deployed |
 helmDefaults | object |  |  |

--- a/ingress/helmfile.yaml
+++ b/ingress/helmfile.yaml
@@ -58,6 +58,10 @@ transformers:
 helmDefaults:
 {{ $__helmDefaults | toYaml | indent 2 }}
 
+{{ if ( hasKey .Values "kubeVersion" ) }}
+kubeVersion: {{ .Values.kubeVersion }}
+{{ end }}
+
 
 # Define default features when undefined
 {{ if not (hasKey .Values "features") }}

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -115,6 +115,7 @@ features | list of strings | [metrics, logs] | *enum of:&nbsp;&nbsp;(metrics \| 
 kube&#8209;prometheus&#8209;stack | object |  |  |
 kube&#8209;prometheus&#8209;stack.mergeValues | boolean | true |  |
 kube&#8209;prometheus&#8209;stack.values | (object *or* list of objects) |  |  |
+kubeVersion | string |  | Specifies the kubernetes API version, useful in helm templating environment |
 labels | object |  | Adds labels to releases on this namespace |
 loki | object |  |  |
 loki.mergeValues | boolean | true |  |

--- a/monitoring/helmfile.yaml
+++ b/monitoring/helmfile.yaml
@@ -58,6 +58,10 @@ transformers:
 helmDefaults:
 {{ $__helmDefaults | toYaml | indent 2 }}
 
+{{ if ( hasKey .Values "kubeVersion" ) }}
+kubeVersion: {{ .Values.kubeVersion }}
+{{ end }}
+
 
 # Define default features when undefined
 {{ if not (hasKey .Values "features") }}

--- a/polygon/README.md
+++ b/polygon/README.md
@@ -116,6 +116,7 @@ flavor | string |  | suitable defaults for a mainnet archive node |
 heimdall | object |  |  |
 heimdall.mergeValues | boolean | true |  |
 heimdall.values | (object *or* list of objects) |  |  |
+kubeVersion | string |  | Specifies the kubernetes API version, useful in helm templating environment |
 labels | object |  | Adds labels to releases on this namespace |
 proxyd | object |  |  |
 proxyd.mergeValues | boolean | true |  |

--- a/polygon/helmfile.yaml
+++ b/polygon/helmfile.yaml
@@ -58,6 +58,10 @@ transformers:
 helmDefaults:
 {{ $__helmDefaults | toYaml | indent 2 }}
 
+{{ if ( hasKey .Values "kubeVersion" ) }}
+kubeVersion: {{ .Values.kubeVersion }}
+{{ end }}
+
 #set default flavor when missing
 {{ if not ( hasKey .Values "flavor" ) }}
 {{ $_ := set .Values "flavor" "mainnet" }}

--- a/postgres-operator/README.md
+++ b/postgres-operator/README.md
@@ -105,6 +105,7 @@ helmfiles:
 | Key | Type | Default | Description |
 | :--- | :---: | :--- | :--- |
 annotations | object |  | Add annotations to releases on this namespace |
+kubeVersion | string |  | Specifies the kubernetes API version, useful in helm templating environment |
 labels | object |  | Adds labels to releases on this namespace |
 postgres&#8209;operator | object |  |  |
 postgres&#8209;operator.mergeValues | boolean | true |  |

--- a/postgres-operator/helmfile.yaml
+++ b/postgres-operator/helmfile.yaml
@@ -58,6 +58,10 @@ transformers:
 helmDefaults:
 {{ $__helmDefaults | toYaml | indent 2 }}
 
+{{ if ( hasKey .Values "kubeVersion" ) }}
+kubeVersion: {{ .Values.kubeVersion }}
+{{ end }}
+
 
 
 #set default namespace

--- a/schema.json
+++ b/schema.json
@@ -535,6 +535,10 @@
                     "helmDefaults": {
                         "$ref": "#/components/schemas/helmDefaults"
                     },
+                    "kubeVersion": {
+                        "description": "Specifies the kubernetes API version, useful in helm templating environment",
+                        "type": "string"
+                    },
                     "targetNamespace": {
                         "description": "Sets the cluster namespace in which the releases will be deployed",
                         "type": "string"

--- a/sealed-secrets/README.md
+++ b/sealed-secrets/README.md
@@ -105,6 +105,7 @@ helmfiles:
 | Key | Type | Default | Description |
 | :--- | :---: | :--- | :--- |
 annotations | object |  | Add annotations to releases on this namespace |
+kubeVersion | string |  | Specifies the kubernetes API version, useful in helm templating environment |
 labels | object |  | Adds labels to releases on this namespace |
 sealed&#8209;secrets | object |  |  |
 sealed&#8209;secrets.mergeValues | boolean | true |  |

--- a/sealed-secrets/helmfile.yaml
+++ b/sealed-secrets/helmfile.yaml
@@ -58,6 +58,10 @@ transformers:
 helmDefaults:
 {{ $__helmDefaults | toYaml | indent 2 }}
 
+{{ if ( hasKey .Values "kubeVersion" ) }}
+kubeVersion: {{ .Values.kubeVersion }}
+{{ end }}
+
 
 
 #set default namespace

--- a/src/schemas/base.cue
+++ b/src/schemas/base.cue
@@ -15,6 +15,8 @@ info: {
 	// Base namespace values interface schema
 	#values: {
 		helmDefaults?: upstreamHelmfile.#helmDefaults
+		// Specifies the kubernetes API version, useful in helm templating environment
+		kubeVersion?: string
 		// Sets the cluster namespace in which the releases will be deployed
 		targetNamespace: string
 		// Add annotations to releases on this namespace

--- a/src/schemas/build_tool.cue
+++ b/src/schemas/build_tool.cue
@@ -48,6 +48,8 @@ _helmfile: {
 
 		helmDefaults: _helmfile._helmDefaults.out
 
+		kubeVersion: _helmfile._kubeVersion.out
+
 		_defaultFlavor: _helmfile._#defaultFlavor & {_namespace: this}
 		defaultFlavor:  _defaultFlavor.out
 
@@ -73,6 +75,7 @@ _helmfile: {
 			_templateBlocks.transforms,
 			_templateBlocks.releaseValues,
 			helmDefaults,
+			kubeVersion,
 			defaultFlavor,
 			defaultFeatures,
 			defaultNamespace,
@@ -116,6 +119,14 @@ _helmfile: {
 
 		helmDefaults:
 		{{ $__helmDefaults | toYaml | indent 2 }}
+
+		"""
+	}
+
+	_kubeVersion: {out: """
+		{{ if ( hasKey .Values \"kubeVersion\" ) }}
+		kubeVersion: {{ .Values.kubeVersion }}
+		{{ end }}
 
 		"""
 	}

--- a/storage/README.md
+++ b/storage/README.md
@@ -117,6 +117,7 @@ helmfiles:
 | :--- | :---: | :--- | :--- |
 annotations | object |  | Add annotations to releases on this namespace |
 features | list of strings | [rawfile] | *enum of:&nbsp;&nbsp;(zfs \| rawfile)* |
+kubeVersion | string |  | Specifies the kubernetes API version, useful in helm templating environment |
 labels | object |  | Adds labels to releases on this namespace |
 openebs | object |  |  |
 openebs.mergeValues | boolean | true |  |

--- a/storage/helmfile.yaml
+++ b/storage/helmfile.yaml
@@ -58,6 +58,10 @@ transformers:
 helmDefaults:
 {{ $__helmDefaults | toYaml | indent 2 }}
 
+{{ if ( hasKey .Values "kubeVersion" ) }}
+kubeVersion: {{ .Values.kubeVersion }}
+{{ end }}
+
 
 # Define default features when undefined
 {{ if not (hasKey .Values "features") }}


### PR DESCRIPTION
### Description
Adds ability to pass along kubeVersions.

Some charts use .Capabilities.APIVersions to template resources, such as in:
```yaml
apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (.Capabilities.APIVersions.Has "autoscaling/v2") }}
```

Notoriously, recent versions of ingress-nginx which seem to break during helm templating, as Capabilities.APIVersions is not available in that environment and needs to be set by helmfile via the kubeVersions parameter.