### PR TITLE
feat(graph): enable servicemonitor and grafana dashboards and datasources for graph-node

### DIFF
--- a/graph/values/_common/graph-node.yaml
+++ b/graph/values/_common/graph-node.yaml
@@ -24,3 +24,11 @@ graphNodeGroups:
     replicaCount: 1 # scale me
   query:
     replicaCount: 1 # scale me
+
+prometheus:
+  serviceMonitors:
+    enabled: true
+
+grafana:
+  dashboards: true
+  datasources: true


### PR DESCRIPTION
Enable service monitors and grafana resources in the graph namespace by default