### PR TITLE
fix: update graph schema to include arbitrum-goerli

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -2519,11 +2519,19 @@
             "namespaces.graph.flavor": {
                 "type": "object"
             },
+            "namespaces.graph.flavor.arbitrum_goerli": {
+                "description": "suitable defaults for an arbitrum-goerli indexer",
+                "type": "string",
+                "enum": [
+                    "arbitrum-goerli"
+                ]
+            },
             "namespaces.graph.flavor.enum": {
                 "type": "string",
                 "enum": [
                     "goerli",
-                    "mainnet"
+                    "mainnet",
+                    "arbitrum-goerli"
                 ]
             },
             "namespaces.graph.flavor.goerli": {

--- a/src/schemas/graph.cue
+++ b/src/schemas/graph.cue
@@ -17,10 +17,13 @@ package LaunchpadNamespaces
 			// suitable defaults for a goerli indexer
 			#goerli: "goerli"
 
+			// suitable defaults for an arbitrum-goerli indexer
+			#arbitrum_goerli: "arbitrum-goerli"
+
 			// suitable defaults for a mainnet indexer
 			#mainnet: "mainnet"
 
-			#enum: ( #goerli | #mainnet )
+			#enum: ( #goerli | #mainnet | #arbitrum_goerli )
 		}
 
 		// Graph namespace values schema

--- a/src/scripts/update-docs.sh
+++ b/src/scripts/update-docs.sh
@@ -2,17 +2,31 @@
 
 set -e
 
-if [[ $(uname -s) == Linux ]]; then
-    base_rpath="realpath"
-elif [[ $(uname -s) == Darwin ]]; then
-    base_rpath="grealpath"
-fi
+get_realpath() {
+  local target_file="$1"
+
+  # Check if 'realpath' exists
+  if command -v realpath >/dev/null 2>&1; then
+    realpath "$target_file"
+  elif command -v grealpath >/dev/null 2>&1; then
+    grealpath "$target_file"
+  else
+    echo "Neither realpath nor grealpath is installed. Exiting."
+    exit 1
+  fi
+}
+
+# if [[ $(uname -s) == Linux ]]; then
+#     base_rpath="realpath"
+# elif [[ $(uname -s) == Darwin ]]; then
+#     base_rpath="grealpath"
+# fi
 
 readonly BASEDIR="$(dirname -- "$0")"
-readonly REPOROOT="$("$base_rpath" "$BASEDIR/../..")"
-readonly GENOPENAPI="$("$base_rpath" "$REPOROOT/src/scripts/generate-openapi.sh")"
-readonly DOCSDIR="$("$base_rpath" "$REPOROOT/src/docs")"
-readonly TEMPLATESDIR="$("$base_rpath" "$DOCSDIR/macros")"
+readonly REPOROOT="$(get_realpath "$BASEDIR/../..")"
+readonly GENOPENAPI="$(get_realpath "$REPOROOT/src/scripts/generate-openapi.sh")"
+readonly DOCSDIR="$(get_realpath "$REPOROOT/src/docs")"
+readonly TEMPLATESDIR="$(get_realpath "$DOCSDIR/macros")"
 
 DATA_API_FILE="$(mktemp)"
 exec 3>"$DATA_API_FILE"

--- a/src/scripts/update-docs.sh
+++ b/src/scripts/update-docs.sh
@@ -16,12 +16,6 @@ get_realpath() {
   fi
 }
 
-# if [[ $(uname -s) == Linux ]]; then
-#     base_rpath="realpath"
-# elif [[ $(uname -s) == Darwin ]]; then
-#     base_rpath="grealpath"
-# fi
-
 readonly BASEDIR="$(dirname -- "$0")"
 readonly REPOROOT="$(get_realpath "$BASEDIR/../..")"
 readonly GENOPENAPI="$(get_realpath "$REPOROOT/src/scripts/generate-openapi.sh")"


### PR DESCRIPTION
also updates update-docs.sh to switch over realpath/grealpath by checking for their existence. latest versions of macos do include `realpath`.