### PR TITLE
fix: avoid overloading keys in environments

### DIFF
--- a/arbitrum/helmfile.yaml
+++ b/arbitrum/helmfile.yaml
@@ -16,9 +16,7 @@ environments:
 
 environments:
   {{ .Environment.Name }}:
-    values:
-      - flavor: {{ .Values.flavor }}
-      - _defaults: {{ .Values._defaults | toYaml | nindent 10 }}
+    values: []
 
 ---
 {{- $_tplTransforms := (print `

--- a/avalanche/helmfile.yaml
+++ b/avalanche/helmfile.yaml
@@ -16,9 +16,7 @@ environments:
 
 environments:
   {{ .Environment.Name }}:
-    values:
-      - flavor: {{ .Values.flavor }}
-      - _defaults: {{ .Values._defaults | toYaml | nindent 10 }}
+    values: []
 
 ---
 {{- $_tplTransforms := (print `

--- a/celo/helmfile.yaml
+++ b/celo/helmfile.yaml
@@ -16,9 +16,7 @@ environments:
 
 environments:
   {{ .Environment.Name }}:
-    values:
-      - flavor: {{ .Values.flavor }}
-      - _defaults: {{ .Values._defaults | toYaml | nindent 10 }}
+    values: []
 
 ---
 {{- $_tplTransforms := (print `

--- a/ethereum/helmfile.yaml
+++ b/ethereum/helmfile.yaml
@@ -28,8 +28,6 @@ environments:
 environments:
   {{ .Environment.Name }}:
     values:
-      - flavor: {{ .Values.flavor }}
-      - _defaults: {{ .Values._defaults | toYaml | nindent 10 }}
       - features: {{ .Values.features | toYaml | nindent 10 }}
       - scaling:
           deployments: {{ .Values.scaling.deployments }}

--- a/gnosis/helmfile.yaml
+++ b/gnosis/helmfile.yaml
@@ -16,9 +16,7 @@ environments:
 
 environments:
   {{ .Environment.Name }}:
-    values:
-      - flavor: {{ .Values.flavor }}
-      - _defaults: {{ .Values._defaults | toYaml | nindent 10 }}
+    values: []
 
 ---
 {{- $_tplTransforms := (print `

--- a/graph/helmfile.yaml
+++ b/graph/helmfile.yaml
@@ -21,8 +21,6 @@ environments:
 environments:
   {{ .Environment.Name }}:
     values:
-      - flavor: {{ .Values.flavor }}
-      - _defaults: {{ .Values._defaults | toYaml | nindent 10 }}
       - features: {{ .Values.features | toYaml | nindent 10 }}
 
 ---

--- a/ingress/helmfile.yaml
+++ b/ingress/helmfile.yaml
@@ -16,7 +16,6 @@ environments:
 environments:
   {{ .Environment.Name }}:
     values:
-      - _defaults: {{ .Values._defaults | toYaml | nindent 10 }}
       - features: {{ .Values.features | toYaml | nindent 10 }}
 
 ---

--- a/monitoring/helmfile.yaml
+++ b/monitoring/helmfile.yaml
@@ -16,7 +16,6 @@ environments:
 environments:
   {{ .Environment.Name }}:
     values:
-      - _defaults: {{ .Values._defaults | toYaml | nindent 10 }}
       - features: {{ .Values.features | toYaml | nindent 10 }}
 
 ---

--- a/polygon/helmfile.yaml
+++ b/polygon/helmfile.yaml
@@ -16,9 +16,7 @@ environments:
 
 environments:
   {{ .Environment.Name }}:
-    values:
-      - flavor: {{ .Values.flavor }}
-      - _defaults: {{ .Values._defaults | toYaml | nindent 10 }}
+    values: []
 
 ---
 {{- $_tplTransforms := (print `

--- a/postgres-operator/helmfile.yaml
+++ b/postgres-operator/helmfile.yaml
@@ -11,8 +11,7 @@ environments:
 
 environments:
   {{ .Environment.Name }}:
-    values:
-      - _defaults: {{ .Values._defaults | toYaml | nindent 10 }}
+    values: []
 
 ---
 {{- $_tplTransforms := (print `

--- a/sealed-secrets/helmfile.yaml
+++ b/sealed-secrets/helmfile.yaml
@@ -11,8 +11,7 @@ environments:
 
 environments:
   {{ .Environment.Name }}:
-    values:
-      - _defaults: {{ .Values._defaults | toYaml | nindent 10 }}
+    values: []
 
 ---
 {{- $_tplTransforms := (print `

--- a/src/schemas/build_tool.cue
+++ b/src/schemas/build_tool.cue
@@ -240,12 +240,16 @@ _helmfile: {
 		this=_namespace: string
 		_flavorOnly:     *false | bool
 
-		_variables: {
-			if _namespaces[this].values.flavor != _|_ {
-				flavor: "{{ .Values.flavor }}"
-			}
-			if _namespaces[this].defaults != _|_ {
-				"_defaults": "{{ .Values._defaults | toYaml | nindent 10 }}"
+		_variables: {}
+
+		if _flavorOnly == true {
+			_variables: {
+				if _namespaces[this].values.flavor != _|_ {
+					flavor: "{{ .Values.flavor }}"
+				}
+				if _namespaces[this].defaults != _|_ {
+					"_defaults": "{{ .Values._defaults | toYaml | nindent 10 }}"
+				}
 			}
 		}
 		if _flavorOnly == false {

--- a/storage/helmfile.yaml
+++ b/storage/helmfile.yaml
@@ -16,7 +16,6 @@ environments:
 environments:
   {{ .Environment.Name }}:
     values:
-      - _defaults: {{ .Values._defaults | toYaml | nindent 10 }}
       - features: {{ .Values.features | toYaml | nindent 10 }}
 
 ---


### PR DESCRIPTION
Environments are being set in multiple YAML documents and get merged in order, as each successive document runs after the previous:
```
environments:
 ...

---

environments:
  ...
```

But each document also has a complex flow in which it runs in multiple passes because of templating logic, references... i.e.:

```
merged environment: &{default  map[_defaults:map[common:map[targetNamespace:sealed-secrets]] helmDefaults:map[recreatePods:false] ingress-nginx:map[values:map[controller:map[hostNetwork:true kind:DaemonSet service:map[externalIPs:[167.235.181.145 167.235.182.9 95.217.150.91 95.217.150.84 65.21.232.5 168.119.74.250 167.114.174.133]] tolerations:[map[effect:NoSchedule key:edge operator:Equal value:true]]]]] kubeVersion:v1.26.9] map[]}
first-pass rendering starting for "helmfile.yaml.part.1": inherited=&{default  map[_defaults:map[common:map[targetNamespace:sealed-secrets]] helmDefaults:map[recreatePods:false] ingress-nginx:map[values:map[controller:map[hostNetwork:true kind:DaemonSet service:map[externalIPs:[167.235.181.145 167.235.182.9 95.217.150.91 95.217.150.84 65.21.232.5 168.119.74.250 167.114.174.133]] tolerations:[map[effect:NoSchedule key:edge operator:Equal value:true]]]]] kubeVersion:v1.26.9] map[]}, overrode=&{default  map[helmDefaults:map[recreatePods:false] ingress-nginx:map[values:map[controller:map[hostNetwork:true kind:DaemonSet service:map[externalIPs:[167.235.181.145 167.235.182.9 95.217.150.91 95.217.150.84 65.21.232.5 168.119.74.250 167.114.174.133]] tolerations:[map[effect:NoSchedule key:edge operator:Equal value:true]]]]] kubeVersion:v1.26.9] map[]}
first-pass uses: &{default  map[_defaults:map[common:map[targetNamespace:sealed-secrets]] helmDefaults:map[recreatePods:false] ingress-nginx:map[values:map[controller:map[hostNetwork:true kind:DaemonSet service:map[externalIPs:[167.235.181.145 167.235.182.9 95.217.150.91 95.217.150.84 65.21.232.5 168.119.74.250 167.114.174.133]] tolerations:[map[effect:NoSchedule key:edge operator:Equal value:true]]]]] kubeVersion:v1.26.9] map[]}
first-pass rendering output of "helmfile.yaml.part.1":
 0: 
 1: environments:
 2:   default:
 3:     values:
 4:       - _test: 
 5:           null
 6:           
 7: 

first-pass produced: &{default  map[_defaults:map[common:map[targetNamespace:sealed-secrets]] _test:<nil> 
helmDefaults:map[recreatePods:false] ingress-nginx:map[values:map[controller:map[hostNetwork:true kind:DaemonSet service:map[externalIPs:[167.235.181.145 167.235.182.9 95.217.150.91 95.217.150.84 65.21.232.5 168.119.74.250 167.114.174.133]] tolerations:[map[effect:NoSchedule key:edge operator:Equal value:true]]]]] kubeVersion:v1.26.9] map[]}
first-pass rendering result of "helmfile.yaml.part.1": {default  map[_defaults:map[common:map[targetNamespace:sealed-secrets]] _test:<nil> helmDefaults:map[recreatePods:false] ingress-nginx:map[values:map[controller:map[hostNetwork:true kind:DaemonSet service:map[externalIPs:[167.235.181.145 167.235.182.9 95.217.150.91 95.217.150.84 65.21.232.5 168.119.74.250 167.114.174.133]] tolerations:[map[effect:NoSchedule key:edge operator:Equal value:true]]]]] kubeVersion:v1.26.9] map[]}
vals:
map[_defaults:map[common:map[targetNamespace:sealed-secrets]] _test:<nil> helmDefaults:map[recreatePods:false] ingress-nginx:map[values:map[controller:map[hostNetwork:true kind:DaemonSet service:map[externalIPs:[167.235.181.145 167.235.182.9 95.217.150.91 95.217.150.84 65.21.232.5 168.119.74.250 167.114.174.133]] tolerations:[map[effect:NoSchedule key:edge operator:Equal value:true]]]]] kubeVersion:v1.26.9]
defaultVals:[]
second-pass rendering result of "helmfile.yaml.part.1":
 0: 
 1: environments:
 2:   default:
 3:     values:
 4:       - _test: 
 5:           common:
 6:             targetNamespace: sealed-secrets
 7:           
 8: 
```
It's only on the second passes that the key `_test`, set to `.Values._defaults`  was correctly loaded.
We were re-defining some keys between documents, namely the `_defaults` key where we were again setting it to itself in a similar logic to: `_defaults: {{ .Values._defaults }}`. But sometimes, given that in the first pass it is being evaluated to `null`, it would then never get set correctly on the second pass.

Fix this by in general avoiding setting again the keys that have already been set previously. It is not needed for our use case as environments get merged between documents anyhow.