### PR TITLE
fix(storage): upgrade snapshot.storage.k8s.io/v1beta1 to v1

### DIFF
--- a/storage/values/openebs-zfs-snapclass.yaml
+++ b/storage/values/openebs-zfs-snapclass.yaml
@@ -1,7 +1,7 @@
 resources:
   openebs–zfs–snapclass:
     kind: VolumeSnapshotClass
-    apiVersion: snapshot.storage.k8s.io/v1beta1
+    apiVersion: snapshot.storage.k8s.io/v1
     metadata:
       name: zfspv-snapclass
       annotations:


### PR DESCRIPTION
### Description
This API has been deprecated for a long time now and has been removed in v1.27
