### PR TITLE
feat: add volumeClaimTemplate labels

### DIFF
--- a/arbitrum-one/helmfile.yaml
+++ b/arbitrum-one/helmfile.yaml
@@ -52,6 +52,9 @@ transformers:
     path: spec/template/metadata/annotations
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/annotations
+    kind: StatefulSet
+    create: true
 - apiVersion: builtin
   kind: LabelTransformer
   metadata:
@@ -66,6 +69,9 @@ transformers:
     path: spec/template/metadata/labels
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/labels
+    kind: StatefulSet
+    create: true
 `) -}}
 {{- $_tplReleaseValues := (print `
 {{- if ( .Values | get .release dict | get "mergeValues" true ) -}}

--- a/celo/helmfile.yaml
+++ b/celo/helmfile.yaml
@@ -52,6 +52,9 @@ transformers:
     path: spec/template/metadata/annotations
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/annotations
+    kind: StatefulSet
+    create: true
 - apiVersion: builtin
   kind: LabelTransformer
   metadata:
@@ -66,6 +69,9 @@ transformers:
     path: spec/template/metadata/labels
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/labels
+    kind: StatefulSet
+    create: true
 `) -}}
 {{- $_tplReleaseValues := (print `
 {{- if ( .Values | get .release dict | get "mergeValues" true ) -}}

--- a/ethereum/helmfile.yaml
+++ b/ethereum/helmfile.yaml
@@ -52,6 +52,9 @@ transformers:
     path: spec/template/metadata/annotations
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/annotations
+    kind: StatefulSet
+    create: true
 - apiVersion: builtin
   kind: LabelTransformer
   metadata:
@@ -66,6 +69,9 @@ transformers:
     path: spec/template/metadata/labels
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/labels
+    kind: StatefulSet
+    create: true
 `) -}}
 {{- $_tplReleaseValues := (print `
 {{- if ( .Values | get .release dict | get "mergeValues" true ) -}}

--- a/gnosis/helmfile.yaml
+++ b/gnosis/helmfile.yaml
@@ -52,6 +52,9 @@ transformers:
     path: spec/template/metadata/annotations
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/annotations
+    kind: StatefulSet
+    create: true
 - apiVersion: builtin
   kind: LabelTransformer
   metadata:
@@ -66,6 +69,9 @@ transformers:
     path: spec/template/metadata/labels
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/labels
+    kind: StatefulSet
+    create: true
 `) -}}
 {{- $_tplReleaseValues := (print `
 {{- if ( .Values | get .release dict | get "mergeValues" true ) -}}

--- a/graph/helmfile.yaml
+++ b/graph/helmfile.yaml
@@ -43,6 +43,9 @@ transformers:
     path: spec/template/metadata/annotations
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/annotations
+    kind: StatefulSet
+    create: true
 - apiVersion: builtin
   kind: LabelTransformer
   metadata:
@@ -57,6 +60,9 @@ transformers:
     path: spec/template/metadata/labels
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/labels
+    kind: StatefulSet
+    create: true
 `) -}}
 {{- $_tplReleaseValues := (print `
 {{- if ( .Values | get .release dict | get "mergeValues" true ) -}}

--- a/ingress/helmfile.yaml
+++ b/ingress/helmfile.yaml
@@ -38,6 +38,9 @@ transformers:
     path: spec/template/metadata/annotations
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/annotations
+    kind: StatefulSet
+    create: true
 - apiVersion: builtin
   kind: LabelTransformer
   metadata:
@@ -52,6 +55,9 @@ transformers:
     path: spec/template/metadata/labels
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/labels
+    kind: StatefulSet
+    create: true
 `) -}}
 {{- $_tplReleaseValues := (print `
 {{- if ( .Values | get .release dict | get "mergeValues" true ) -}}

--- a/monitoring/helmfile.yaml
+++ b/monitoring/helmfile.yaml
@@ -38,6 +38,9 @@ transformers:
     path: spec/template/metadata/annotations
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/annotations
+    kind: StatefulSet
+    create: true
 - apiVersion: builtin
   kind: LabelTransformer
   metadata:
@@ -52,6 +55,9 @@ transformers:
     path: spec/template/metadata/labels
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/labels
+    kind: StatefulSet
+    create: true
 `) -}}
 {{- $_tplReleaseValues := (print `
 {{- if ( .Values | get .release dict | get "mergeValues" true ) -}}

--- a/polygon/helmfile.yaml
+++ b/polygon/helmfile.yaml
@@ -38,6 +38,9 @@ transformers:
     path: spec/template/metadata/annotations
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/annotations
+    kind: StatefulSet
+    create: true
 - apiVersion: builtin
   kind: LabelTransformer
   metadata:
@@ -52,6 +55,9 @@ transformers:
     path: spec/template/metadata/labels
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/labels
+    kind: StatefulSet
+    create: true
 `) -}}
 {{- $_tplReleaseValues := (print `
 {{- if ( .Values | get .release dict | get "mergeValues" true ) -}}

--- a/postgres-operator/helmfile.yaml
+++ b/postgres-operator/helmfile.yaml
@@ -33,6 +33,9 @@ transformers:
     path: spec/template/metadata/annotations
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/annotations
+    kind: StatefulSet
+    create: true
 - apiVersion: builtin
   kind: LabelTransformer
   metadata:
@@ -47,6 +50,9 @@ transformers:
     path: spec/template/metadata/labels
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/labels
+    kind: StatefulSet
+    create: true
 `) -}}
 {{- $_tplReleaseValues := (print `
 {{- if ( .Values | get .release dict | get "mergeValues" true ) -}}

--- a/sealed-secrets/helmfile.yaml
+++ b/sealed-secrets/helmfile.yaml
@@ -33,6 +33,9 @@ transformers:
     path: spec/template/metadata/annotations
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/annotations
+    kind: StatefulSet
+    create: true
 - apiVersion: builtin
   kind: LabelTransformer
   metadata:
@@ -47,6 +50,9 @@ transformers:
     path: spec/template/metadata/labels
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/labels
+    kind: StatefulSet
+    create: true
 `) -}}
 {{- $_tplReleaseValues := (print `
 {{- if ( .Values | get .release dict | get "mergeValues" true ) -}}

--- a/src/schemas/arbitrum-one.cue
+++ b/src/schemas/arbitrum-one.cue
@@ -62,7 +62,7 @@ package LaunchpadNamespaces
 
 		// arbitrum-one helmfile API
 		#helmfiles: #base.#helmfiles & {
-			path:    =~"*github.com/graphops/launchpad-namespaces.git@arbitrum-one/helmfile.yaml*"
+			path: =~"*github.com/graphops/launchpad-namespaces.git@arbitrum-one/helmfile.yaml*"
 			values?: #arbitrumOne.#values | [...#arbitrumOne.#values]
 		}
 

--- a/src/schemas/base.cue
+++ b/src/schemas/base.cue
@@ -63,8 +63,8 @@ info: {
 
 // template for instantiating namespace ojects for internal usage
 _#namespaceTemplate: {
-	_key:   _
-	meta:   _key.meta
+	_key: _
+	meta: _key.meta
 	values: _key.#values & {
 		targetNamespace: _key.#values.targetNamespace
 		if _key.#features != _|_ {features: [..._key.#features.#enum]}

--- a/src/schemas/build_tool.cue
+++ b/src/schemas/build_tool.cue
@@ -14,29 +14,29 @@ command: {
 		var: {
 			namespace: string @tag(namespace)
 		}
-		_out:  _helmfile.#render & {_namespace: var.namespace}
-		print: cli.Print & {text:               _out.out}
+		_out: _helmfile.#render & {_namespace: var.namespace}
+		print: cli.Print & {text: _out.out}
 	}
 	"build:renovate": {
-		_out:  _renovate.render
+		_out:                     _renovate.render
 		print: cli.Print & {text: _out.out}
 	}
 }
 
 _renovate: {
 	_#repo: {
-		_repo:   string
-		_url:    _repositories[_repo].url
+		_repo: string
+		_url:  _repositories[_repo].url
 		_struct: {
 			matchDepPatterns: "\(_repo)\\/.*"
 			registryUrls: ["\(_url)"]
 		} & {if _repositories[_repo]._renovate != _|_ {_repositories[_repo]._renovate}}
 		render: json.Marshal(_struct)
-		out:    strings.Join([ for line in strings.Split(render, "\n") {"      " + line}], "\n")
+		out: strings.Join([for line in strings.Split(render, "\n") {"      " + line}], "\n")
 	}
 	render: {
-		_blocks: [ for repoName, _ in _repositories {_#repo & {_repo: repoName}}]
-		out: strings.Join([ for block in _blocks {block.out}], ",\n")
+		_blocks: [for repoName, _ in _repositories {_#repo & {_repo: repoName}}]
+		out: strings.Join([for block in _blocks {block.out}], ",\n")
 	}
 }
 
@@ -53,16 +53,16 @@ _helmfile: {
 		kubeVersion: _helmfile._kubeVersion.out
 
 		_setDefaults: _helmfile._#setDefaults & {_namespace: this}
-		setDefaults:  _setDefaults.out
+		setDefaults: _setDefaults.out
 
 		_defaultFlavor: _helmfile._#defaultFlavor & {_namespace: this}
-		defaultFlavor:  _defaultFlavor.out
+		defaultFlavor: _defaultFlavor.out
 
 		_defaultFeatures: _helmfile._#defaultFeatures & {_namespace: this}
-		defaultFeatures:  _defaultFeatures.out
+		defaultFeatures: _defaultFeatures.out
 
 		_defaultScaling: _helmfile._#defaultScaling & {_namespace: this}
-		defaultScaling:  _defaultScaling.out
+		defaultScaling: _defaultScaling.out
 
 		_environmentFlavor: _helmfile._#environment & {
 			_namespace:  this
@@ -71,21 +71,21 @@ _helmfile: {
 		environmentFlavor: _environmentFlavor.out
 
 		_environment: _helmfile._#environment & {_namespace: this}
-		environment:  _environment.out
+		environment: _environment.out
 
 		_defaultNamespace: _helmfile._#defaultNamespace & {_namespace: this}
-		defaultNamespace:  _defaultNamespace.out
+		defaultNamespace: _defaultNamespace.out
 
 		_labels: _helmfile._#labels & {_namespace: this}
-		labels:  _labels.out
+		labels: _labels.out
 
 		_templates: _helmfile._#templates & {_namespace: this}
-		templates:  _templates.out
+		templates: _templates.out
 
 		_releases: _helmfile._#releases & {_namespace: this}
-		releases:  _releases.out
+		releases: _releases.out
 
-		_repos:       _helmfile._repos & {_namespace: this}
+		_repos: _helmfile._repos & {_namespace: this}
 		repositories: _repos.out
 
 		out: strings.Join([
@@ -127,8 +127,8 @@ _helmfile: {
 			}
 		}
 
-		_render:   yaml.Marshal([ for repoName, repo in repositoriesSet {repo}])
-		_indented: strings.Join([ for line in strings.Split(_render, "\n") {"  " + line}], "\n")
+		_render: yaml.Marshal([for repoName, repo in repositoriesSet {repo}])
+		_indented: strings.Join([for line in strings.Split(_render, "\n") {"  " + line}], "\n")
 
 		out: strings.Join(["repositories:", _indented], "\n")
 	}
@@ -264,7 +264,7 @@ _helmfile: {
 			}
 		}
 
-		_yaml:       yaml.Marshal({environments: "{{ .Environment.Name }}": values: [ for key, value in _variables {(key): value}]})
+		_yaml: yaml.Marshal({environments: "{{ .Environment.Name }}": values: [for key, value in _variables {(key): value}]})
 		_yamlCleanP: strings.Replace(_yaml, "'{{", "{{", -1)
 		_yamlCleanS: strings.Replace(_yamlCleanP, "}}'", "}}", -1)
 		_yamlClean:  _yamlCleanS
@@ -298,15 +298,15 @@ _helmfile: {
 			for key, value in _struct if !strings.Contains("\(value)", "{{") {"\(key)": "`\(key)` `\(value)`"}
 		}
 
-		_templatedElementsList: list.SortStrings([ for key, value in _struct if strings.Contains("\(value)", "{{") {"\(key)"}])
+		_templatedElementsList: list.SortStrings([for key, value in _struct if strings.Contains("\(value)", "{{") {"\(key)"}])
 
 		_elements: {
 			for index, key in _templatedElementsList {"\(key)": "`\(key)` $_templatedValue_\(index)"}
 		}
 
-		_elementsStrings: [ for key, value in _elements {"\(value)"}]
+		_elementsStrings: [for key, value in _elements {"\(value)"}]
 
-		_variableDecl: [ for index, key in _templatedElementsList let value = strings.Replace(strings.Replace(_struct[key], "{{", "", 1), "}}", "", 1) {
+		_variableDecl: [for index, key in _templatedElementsList let value = strings.Replace(strings.Replace(_struct[key], "{{", "", 1), "}}", "", 1) {
 			"""
 		{{- $_templatedValue_\(index) := \(value) }}
 		"""
@@ -324,7 +324,7 @@ _helmfile: {
 		}
 
 		if _indent > 0 {
-			out: strings.Join([ for line in strings.Split(_out, "\n") {" "*_indent + line}], "\n")
+			out: strings.Join([for line in strings.Split(_out, "\n") {" "*_indent + line}], "\n")
 		}
 	}
 
@@ -333,7 +333,7 @@ _helmfile: {
 		_struct: {...}
 		_indent: *0 | int
 
-		_yaml:       yaml.Marshal({"\(_name)": _struct})
+		_yaml: yaml.Marshal({"\(_name)": _struct})
 		_yamlCleanP: strings.Replace(_yaml, "'{{", "{{", -1)
 		_yamlCleanS: strings.Replace(_yamlCleanP, "}}'", "}}", -1)
 		_yamlClean:  _yamlCleanS
@@ -345,7 +345,7 @@ _helmfile: {
 		}
 
 		if _indent > 0 {
-			out: strings.Join([ for line in strings.Split(_out, "\n") {" "*_indent + line}], "\n")
+			out: strings.Join([for line in strings.Split(_out, "\n") {" "*_indent + line}], "\n")
 		}
 	}
 
@@ -445,8 +445,8 @@ _helmfile: {
 			}
 		}
 
-		_allblocks:      strings.Join([ for name, block in _blocks {block}], "\n")
-		_indentedBlocks: strings.Join([ for line in strings.Split(_allblocks, "\n") {"  " + line}], "\n")
+		_allblocks: strings.Join([for name, block in _blocks {block}], "\n")
+		_indentedBlocks: strings.Join([for line in strings.Split(_allblocks, "\n") {"  " + line}], "\n")
 
 		out: strings.Join(["templates:", _indentedBlocks], "\n")
 	}
@@ -532,9 +532,9 @@ _helmfile: {
 				_props: {"\(releaseName)": {#properties: {
 					...
 					_labels: {for key, value in release.labels {"\(key)": value}}
-					_yamlLabels:     yaml.Marshal(_labels)
-					_indentedLabels: strings.Join([ for line in strings.Split(_yamlLabels, "\n") {"    " + line}], "\n")
-					_releaseLabels:  strings.Join(["labels:", _indentedLabels], "\n")
+					_yamlLabels: yaml.Marshal(_labels)
+					_indentedLabels: strings.Join([for line in strings.Split(_yamlLabels, "\n") {"    " + line}], "\n")
+					_releaseLabels: strings.Join(["labels:", _indentedLabels], "\n")
 				}}}
 			}
 
@@ -578,17 +578,17 @@ _helmfile: {
 			if release.feature != _|_ {
 				_blocks: {
 					"\(releaseName)": strings.Join([
-								"{{ if has \"\(release.feature)\" ( .Values | get \"features\" list ) }}",
-								temp.out,
-								"{{- end -}}",
+						"{{ if has \"\(release.feature)\" ( .Values | get \"features\" list ) }}",
+						temp.out,
+						"{{- end -}}",
 					], "\n")
 				}
 
 			}
 		}
 
-		_allblocks:      strings.Join([ for name, block in _blocks {block}], "\n")
-		_indentedBlocks: strings.Join([ for line in strings.Split(_allblocks, "\n") {"  " + line}], "\n")
+		_allblocks: strings.Join([for name, block in _blocks {block}], "\n")
+		_indentedBlocks: strings.Join([for line in strings.Split(_allblocks, "\n") {"  " + line}], "\n")
 
 		out: strings.Join(["releases:", _indentedBlocks], "\n")
 	}
@@ -615,6 +615,9 @@ _templateBlocks: {
 		    path: spec/template/metadata/annotations
 		    create: true
 		{{- end }}
+		  - path: spec/volumeClaimTemplates[]/metadata/annotations
+		    kind: StatefulSet
+		    create: true
 		- apiVersion: builtin
 		  kind: LabelTransformer
 		  metadata:
@@ -629,6 +632,9 @@ _templateBlocks: {
 		    path: spec/template/metadata/labels
 		    create: true
 		{{- end }}
+		  - path: spec/volumeClaimTemplates[]/metadata/labels
+		    kind: StatefulSet
+		    create: true
 		`) -}}
 		"""
 

--- a/src/schemas/celo.cue
+++ b/src/schemas/celo.cue
@@ -64,7 +64,7 @@ package LaunchpadNamespaces
 
 		// celo helmfile API
 		#helmfiles: #base.#helmfiles & {
-			path:    =~"*github.com/graphops/launchpad-namespaces.git@celo/helmfile.yaml*"
+			path: =~"*github.com/graphops/launchpad-namespaces.git@celo/helmfile.yaml*"
 			values?: #celo.#values | [...#celo.#values]
 		}
 

--- a/src/schemas/ethereum.cue
+++ b/src/schemas/ethereum.cue
@@ -71,7 +71,7 @@ package LaunchpadNamespaces
 
 		// ethereum helmfile API
 		#helmfiles: #base.#helmfiles & {
-			path:    =~"*github.com/graphops/launchpad-namespaces.git@ethereum/helmfile.yaml*"
+			path: =~"*github.com/graphops/launchpad-namespaces.git@ethereum/helmfile.yaml*"
 			values?: #ethereum.#values | [...#ethereum.#values]
 		}
 

--- a/src/schemas/gnosis.cue
+++ b/src/schemas/gnosis.cue
@@ -63,7 +63,7 @@ package LaunchpadNamespaces
 
 		// gnosis helmfile API
 		#helmfiles: #base.#helmfiles & {
-			path:    =~"*github.com/graphops/launchpad-namespaces.git@gnosis/helmfile.yaml*"
+			path: =~"*github.com/graphops/launchpad-namespaces.git@gnosis/helmfile.yaml*"
 			values?: #gnosis.#values | [...#gnosis.#values]
 		}
 

--- a/src/schemas/graph.cue
+++ b/src/schemas/graph.cue
@@ -53,7 +53,7 @@ package LaunchpadNamespaces
 
 		// Graph helmfile API
 		#helmfiles: #base.#helmfiles & {
-			path:    =~"*github.com/graphops/launchpad-namespaces.git@graph/helmfile.yaml*"
+			path: =~"*github.com/graphops/launchpad-namespaces.git@graph/helmfile.yaml*"
 			values?: #graph.#values | [...#graph.#values]
 		}
 

--- a/src/schemas/ingress.cue
+++ b/src/schemas/ingress.cue
@@ -38,7 +38,7 @@ package LaunchpadNamespaces
 		}
 
 		#helmfiles: #base.#helmfiles & {
-			path:    =~"*github.com/graphops/launchpad-namespaces.git@ingress/helmfile.yaml*"
+			path: =~"*github.com/graphops/launchpad-namespaces.git@ingress/helmfile.yaml*"
 			values?: #ingress.#values | [...#ingress.#values]
 		}
 

--- a/src/schemas/monitoring.cue
+++ b/src/schemas/monitoring.cue
@@ -35,7 +35,7 @@ package LaunchpadNamespaces
 		}
 
 		#helmfiles: #base.#helmfiles & {
-			path:    =~"*github.com/graphops/launchpad-namespaces.git@monitoring/helmfile.yaml*"
+			path: =~"*github.com/graphops/launchpad-namespaces.git@monitoring/helmfile.yaml*"
 			values?: #monitoring.#values | [...#monitoring.#values]
 		}
 

--- a/src/schemas/polygon.cue
+++ b/src/schemas/polygon.cue
@@ -35,7 +35,7 @@ package LaunchpadNamespaces
 
 		// polygon helmfile API
 		#helmfiles: #base.#helmfiles & {
-			path:    =~"*github.com/graphops/launchpad-namespaces.git@polygon/helmfile.yaml*"
+			path: =~"*github.com/graphops/launchpad-namespaces.git@polygon/helmfile.yaml*"
 			values?: #polygon.#values | [...#polygon.#values]
 		}
 

--- a/src/schemas/postgres-operator.cue
+++ b/src/schemas/postgres-operator.cue
@@ -23,7 +23,7 @@ package LaunchpadNamespaces
 		}
 
 		#helmfiles: #base.#helmfiles & {
-			path:    =~"*github.com/graphops/launchpad-namespaces.git@postgres-operator/helmfile.yaml*"
+			path: =~"*github.com/graphops/launchpad-namespaces.git@postgres-operator/helmfile.yaml*"
 			values?: #values | [...#values]
 		}
 

--- a/src/schemas/sealed-secrets.cue
+++ b/src/schemas/sealed-secrets.cue
@@ -23,7 +23,7 @@ package LaunchpadNamespaces
 		}
 
 		#helmfiles: #base.#helmfiles & {
-			path:    =~"*github.com/graphops/launchpad-namespaces.git@sealed-secrets/helmfile.yaml*"
+			path: =~"*github.com/graphops/launchpad-namespaces.git@sealed-secrets/helmfile.yaml*"
 			values?: #values | [...#values]
 		}
 

--- a/src/schemas/storage.cue
+++ b/src/schemas/storage.cue
@@ -36,7 +36,7 @@ package LaunchpadNamespaces
 			}
 		}
 		#helmfiles: #base.#helmfiles & {
-			path:    =~"*github.com/graphops/launchpad-namespaces.git@storage/helmfile.yaml*"
+			path: =~"*github.com/graphops/launchpad-namespaces.git@storage/helmfile.yaml*"
 			values?: #storage.#values | [...#storage.#values]
 		}
 

--- a/storage/helmfile.yaml
+++ b/storage/helmfile.yaml
@@ -38,6 +38,9 @@ transformers:
     path: spec/template/metadata/annotations
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/annotations
+    kind: StatefulSet
+    create: true
 - apiVersion: builtin
   kind: LabelTransformer
   metadata:
@@ -52,6 +55,9 @@ transformers:
     path: spec/template/metadata/labels
     create: true
 {{- end }}
+  - path: spec/volumeClaimTemplates[]/metadata/labels
+    kind: StatefulSet
+    create: true
 `) -}}
 {{- $_tplReleaseValues := (print `
 {{- if ( .Values | get .release dict | get "mergeValues" true ) -}}


### PR DESCRIPTION
Current labels and annotations transforms were not adding labels to volumeClaimTemplates, so that PVCs created by the stateful sets would end up with the same labels as other resources.
This addition rectifies that (for both labels and annotations).