### PR TITLE
fix(graph-network-indexer): indexer-service replica typo

### DIFF
--- a/graph/values/_common/graph-network-indexer.yaml
+++ b/graph/values/_common/graph-network-indexer.yaml
@@ -31,7 +31,7 @@ indexerAgent:
 
 
 indexerService:
-  replicaCount: 1 # scale me
+  replicas: 1 # scale me
 
   env: {}
 


### PR DESCRIPTION
See https://github.com/graphops/launchpad-charts/blob/1f6ff573dc45a096bbf5b8bdeb8030e535fd0c46/charts/graph-network-indexer/values.yaml#L164