### PR TITLE
chore: adapt to new module.cue format

### DIFF
--- a/src/cue.mod/module.cue
+++ b/src/cue.mod/module.cue
@@ -1,1 +1,4 @@
 module: "graphops.xyz/launchpad/namespaces"
+language: {
+	version: "v0.9.0"
+}


### PR DESCRIPTION
Declare a language version for compatibility with cue post v0.9

Closes https://github.com/graphops/launchpad-namespaces/issues/727