### PR TITLE
fix: 404 link charts.cue

### DIFF
--- a/src/charts.cue
+++ b/src/charts.cue
@@ -23,7 +23,7 @@ package LaunchpadNamespaces
 					"""
 			}
 			proxyd: {
-				url: "https://github.com/ethereum-optimism/optimism/tree/develop/proxyd"
+				url: "https://github.com/ethereum-optimism/infra/tree/main/proxyd"
 				description: """
 					Proxyd is an EVM-blockchain JSON-RPC router and load balancer developed in Go by Optimism. It is capable of load balancing, automatic failover, intelligent request routing and very basic caching.
 					"""


### PR DESCRIPTION
Hi! I fixes a broken link in the `charts.cue` file. The old link pointed to a deprecated or non-existent path for the `proxyd` repository in the `optimism` monorepo. It has been updated to the correct and current path in the `infra` repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated an external resource link for a chart component to ensure it directs to the correct repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->