### PR TITLE
docs: fix typo in documentation

### DIFF
--- a/polygon/README.md
+++ b/polygon/README.md
@@ -152,7 +152,7 @@ scaling | object |  | polygon scaling interface |
 scaling.deployments | integer | 1 | number of independent stateful sets to deploy |
 scaling.erigon | object |  |  |
 scaling.heimdall | object |  |  |
-scaling.startP2PPort | integer |  | A beggining port for the range to use in P2P NodePorts |
+scaling.startP2PPort | integer |  | A beginning port for the range to use in P2P NodePorts |
 targetNamespace | string | polygon-mainnet | the default is polygon-<flavor> |
 helmDefaults | object |  |  |
 helmDefaults.args | list of strings |  |  |


### PR DESCRIPTION
### Description

<img width="943" alt="Снимок экрана 2025-03-05 в 18 22 18" src="https://github.com/user-attachments/assets/74bc0c3e-e266-4337-997c-cd4984bd2524" />

I noticed a typo in the documentation where "beggining" was used instead of the correct spelling "beginning."
I’ve fixed it to ensure accuracy.