### PR TITLE
feat(graph): revert to stable network-indexer chart

### DIFF
--- a/graph/helmfile.yaml
+++ b/graph/helmfile.yaml
@@ -173,7 +173,7 @@ templates:
     version: {{ .Values | get "graph-network-indexer" | get "chartVersion" }}
     {{- end }}
     {{- if (not (or ( .Values | get "graph-network-indexer" dict | get "chartVersion" false ) ( .Values | get "graph-network-indexer" dict | get "chartUrl" false ) )) }}
-    version: "0.5.20-canary.4"
+    version: "0.5.19"
     {{- end }}
   
   graph-toolbox:

--- a/src/schemas/graph.cue
+++ b/src/schemas/graph.cue
@@ -94,7 +94,7 @@ package LaunchpadNamespaces
 			"graph-network-indexer": {
 				chart: {_repositories.graphops.charts["graph-network-indexer"]}
 				feature: #features.#network_indexer
-				_template: {version: "0.5.20-canary.4"}
+				_template: {version: "0.5.19"}
 			}
 
 			"graph-toolbox": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default version of "graph-network-indexer" to 0.5.19 in deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->